### PR TITLE
Fixed zero leechers/seeders which would overflow on cast

### DIFF
--- a/aquatic_udp/src/workers/swarm/mod.rs
+++ b/aquatic_udp/src/workers/swarm/mod.rs
@@ -163,8 +163,9 @@ fn handle_announce_request<I: Ip>(
     AnnounceResponse {
         transaction_id: request.transaction_id,
         announce_interval: AnnounceInterval(config.protocol.peer_announce_interval),
-        leechers: NumberOfPeers(torrent_data.num_leechers() as i32),
-        seeders: NumberOfPeers(torrent_data.num_seeders() as i32),
+        // convert usize torrent_data.num_leechers() to i32
+        leechers: NumberOfPeers(torrent_data.num_leechers().try_into().unwrap_or(0)),
+        seeders: NumberOfPeers(torrent_data.num_seeders().try_into().unwrap_or(0)),
         peers: response_peers,
     }
 }


### PR DESCRIPTION
### Issue
Seeders and leecher overflow when zero (usize -> i32) on Announce Response in some torrent clients.
### Fix
using `try_into()` and defaulting to zero on unwrap, instead of a `as` cast.

I'm not a Rust expert by any means so this may not be the most optimal way to fix the issue. This might also be system dependant since it's a issue relating to usize.
This pull request only fixes the udp version of aquatic, other protocols don't seem to be affected (?).

See user issue [ngosang/trackerslist/issues/396](https://github.com/ngosang/trackerslist/issues/396#issuecomment-1249867745)
Reproduced locally with Tixati