### PR TITLE
feat: add Option<> types and added a space after value

### DIFF
--- a/crates/toml_config/src/lib.rs
+++ b/crates/toml_config/src/lib.rs
@@ -33,6 +33,10 @@ macro_rules! gen_serialize_deserialize_test {
 ///     a: usize,
 ///     /// B
 ///     b: String,
+///     /// C
+///     c: Option<String>,
+///     /// D
+///     d: Option<usize>,
 /// }
 ///
 /// impl Default for SubConfig {
@@ -40,6 +44,8 @@ macro_rules! gen_serialize_deserialize_test {
 ///         Self {
 ///             a: 200,
 ///             b: "subconfig hello".into(),
+///             c: None,
+///             d: Some(200),
 ///         }
 ///     }
 /// }
@@ -64,7 +70,7 @@ macro_rules! gen_serialize_deserialize_test {
 ///     }
 /// }
 ///
-/// let expected = "# A\na = 100\n# B\nb = \"hello\"\n\n# C\n[c]\n# A\na = 200\n# B\nb = \"subconfig hello\"\n";
+/// let expected = "# A\na = 100\n\n# B\nb = \"hello\"\n\n\n# C\n[c]\n# A\na = 200\n\n# B\nb = \"subconfig hello\"\n\n# C\n#c = \n\n# D\nd = 200\n\n";
 ///
 /// assert_eq!(
 ///     Config::default_to_string(),
@@ -100,33 +106,7 @@ pub mod __private {
                     output
                 }
             }
-        };
-    }
 
-    impl_trait!(isize);
-    impl_trait!(i8);
-    impl_trait!(i16);
-    impl_trait!(i32);
-    impl_trait!(i64);
-
-    impl_trait!(usize);
-    impl_trait!(u8);
-    impl_trait!(u16);
-    impl_trait!(u32);
-    impl_trait!(u64);
-
-    impl_trait!(f32);
-    impl_trait!(f64);
-
-    impl_trait!(bool);
-
-    impl_trait!(String);
-
-    impl_trait!(PathBuf);
-    impl_trait!(SocketAddr);
-
-    macro_rules! impl_option_trait {
-        ($ident:ident) => {
             impl Private for Option<$ident> {
                 fn __to_string(&self, comment: Option<String>, field_name: String) -> String {
                     let mut output = String::new();
@@ -151,25 +131,25 @@ pub mod __private {
         };
     }
 
-    impl_option_trait!(isize);
-    impl_option_trait!(i8);
-    impl_option_trait!(i16);
-    impl_option_trait!(i32);
-    impl_option_trait!(i64);
+    impl_trait!(isize);
+    impl_trait!(i8);
+    impl_trait!(i16);
+    impl_trait!(i32);
+    impl_trait!(i64);
 
-    impl_option_trait!(usize);
-    impl_option_trait!(u8);
-    impl_option_trait!(u16);
-    impl_option_trait!(u32);
-    impl_option_trait!(u64);
+    impl_trait!(usize);
+    impl_trait!(u8);
+    impl_trait!(u16);
+    impl_trait!(u32);
+    impl_trait!(u64);
 
-    impl_option_trait!(f32);
-    impl_option_trait!(f64);
+    impl_trait!(f32);
+    impl_trait!(f64);
 
-    impl_option_trait!(bool);
+    impl_trait!(bool);
 
-    impl_option_trait!(String);
+    impl_trait!(String);
 
-    impl_option_trait!(PathBuf);
-    impl_option_trait!(SocketAddr);
+    impl_trait!(PathBuf);
+    impl_trait!(SocketAddr);
 }

--- a/crates/toml_config/src/lib.rs
+++ b/crates/toml_config/src/lib.rs
@@ -141,7 +141,7 @@ pub mod __private {
                             output.push_str(&format!("{} = {}\n\n", field_name, value));
                         }
                         None => {
-                            output.push_str(&format!("{} = null\n\n", field_name));
+                            output.push_str(&format!("#{} = \n\n", field_name));
                         }
                     }
 

--- a/crates/toml_config/src/lib.rs
+++ b/crates/toml_config/src/lib.rs
@@ -1,5 +1,6 @@
-pub use aquatic_toml_config_derive::TomlConfig;
 pub use toml;
+
+pub use aquatic_toml_config_derive::TomlConfig;
 
 /// Run this on your struct implementing TomlConfig to generate a
 /// serialization/deserialization test for it.
@@ -94,7 +95,7 @@ pub mod __private {
 
                     let value = crate::toml::ser::to_string(self).unwrap();
 
-                    output.push_str(&format!("{} = {}\n", field_name, value));
+                    output.push_str(&format!("{} = {}\n\n", field_name, value));
 
                     output
                 }
@@ -123,4 +124,52 @@ pub mod __private {
 
     impl_trait!(PathBuf);
     impl_trait!(SocketAddr);
+
+    macro_rules! impl_option_trait {
+        ($ident:ident) => {
+            impl Private for Option<$ident> {
+                fn __to_string(&self, comment: Option<String>, field_name: String) -> String {
+                    let mut output = String::new();
+
+                    if let Some(comment) = comment {
+                        output.push_str(&comment);
+                    }
+
+                    match self {
+                        Some(value) => {
+                            let value = crate::toml::ser::to_string(value).unwrap();
+                            output.push_str(&format!("{} = {}\n\n", field_name, value));
+                        }
+                        None => {
+                            output.push_str(&format!("{} = null\n\n", field_name));
+                        }
+                    }
+
+                    output
+                }
+            }
+        };
+    }
+
+    impl_option_trait!(isize);
+    impl_option_trait!(i8);
+    impl_option_trait!(i16);
+    impl_option_trait!(i32);
+    impl_option_trait!(i64);
+
+    impl_option_trait!(usize);
+    impl_option_trait!(u8);
+    impl_option_trait!(u16);
+    impl_option_trait!(u32);
+    impl_option_trait!(u64);
+
+    impl_option_trait!(f32);
+    impl_option_trait!(f64);
+
+    impl_option_trait!(bool);
+
+    impl_option_trait!(String);
+
+    impl_option_trait!(PathBuf);
+    impl_option_trait!(SocketAddr);
 }

--- a/crates/toml_config/tests/test.rs
+++ b/crates/toml_config/tests/test.rs
@@ -8,6 +8,10 @@ struct TestConfigInnerA {
     a: String,
     /// Comment for b
     b: usize,
+    /// Comment for c
+    c: Option<String>,
+    /// Comment for d
+    d: Option<usize>,
 }
 
 impl Default for TestConfigInnerA {
@@ -15,6 +19,8 @@ impl Default for TestConfigInnerA {
         Self {
             a: "Inner hello world".into(),
             b: 100,
+            c: None,
+            d: Some(200),
         }
     }
 }


### PR DESCRIPTION
Hey, I really like your config 2 toml implementation, but I am missing `Option<>` types. Please take a look at this pr.