### PR TITLE
dev: add ordinal compare to udp primitive types

### DIFF
--- a/crates/udp_protocol/src/common.rs
+++ b/crates/udp_protocol/src/common.rs
@@ -18,7 +18,21 @@ impl AnnounceInterval {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
+impl Ord for AnnounceInterval {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for AnnounceInterval {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes,
+)]
 #[repr(transparent)]
 pub struct InfoHash(pub [u8; 20]);
 
@@ -32,6 +46,18 @@ impl ConnectionId {
     }
 }
 
+impl Ord for ConnectionId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for ConnectionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
 #[repr(transparent)]
 pub struct TransactionId(pub I32);
@@ -39,6 +65,18 @@ pub struct TransactionId(pub I32);
 impl TransactionId {
     pub fn new(v: i32) -> Self {
         Self(I32::new(v))
+    }
+}
+
+impl Ord for TransactionId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for TransactionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
     }
 }
 
@@ -52,6 +90,18 @@ impl NumberOfBytes {
     }
 }
 
+impl Ord for NumberOfBytes {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for NumberOfBytes {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
 #[repr(transparent)]
 pub struct NumberOfPeers(pub I32);
@@ -59,6 +109,18 @@ pub struct NumberOfPeers(pub I32);
 impl NumberOfPeers {
     pub fn new(v: i32) -> Self {
         Self(I32::new(v))
+    }
+}
+
+impl Ord for NumberOfPeers {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for NumberOfPeers {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
     }
 }
 
@@ -72,6 +134,18 @@ impl NumberOfDownloads {
     }
 }
 
+impl Ord for NumberOfDownloads {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for NumberOfDownloads {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
 #[repr(transparent)]
 pub struct Port(pub U16);
@@ -79,6 +153,18 @@ pub struct Port(pub U16);
 impl Port {
     pub fn new(v: NonZeroU16) -> Self {
         Self(U16::new(v.into()))
+    }
+}
+
+impl Ord for Port {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for Port {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
     }
 }
 
@@ -92,14 +178,30 @@ impl PeerKey {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, AsBytes, FromBytes, FromZeroes)]
+impl Ord for PeerKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.get().cmp(&other.0.get())
+    }
+}
+
+impl PartialOrd for PeerKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash, AsBytes, FromBytes, FromZeroes,
+)]
 #[repr(C, packed)]
 pub struct ResponsePeer<I: Ip> {
     pub ip_address: I,
     pub port: Port,
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes,
+)]
 #[repr(transparent)]
 pub struct Ipv4AddrBytes(pub [u8; 4]);
 
@@ -117,7 +219,9 @@ impl From<Ipv4Addr> for Ipv4AddrBytes {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes)]
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes,
+)]
 #[repr(transparent)]
 pub struct Ipv6AddrBytes(pub [u8; 16]);
 


### PR DESCRIPTION
Adds Ordinal Compare to the Primitive Types in: https://github.com/greatest-ape/aquatic/blob/master/crates/udp_protocol/src/common.rs

closes #206 