### PR TITLE
Update bencher README with torrust tracker commit

### DIFF
--- a/crates/bencher/README.md
+++ b/crates/bencher/README.md
@@ -13,7 +13,7 @@ Currently, only UDP BitTorrent tracker support is implemented.
 | [aquatic_udp]     | (use same as bencher) |
 | [opentracker]     | 110868e               |
 | [chihaya]         | 2f79440               |
-| [torrust-tracker] | 47c2fe2               |
+| [torrust-tracker] | eaa86a7               |
 
 The commits listed are ones known to work. It might be a good idea to first
 test with the latest commits for each project, and if they don't seem to work,


### PR DESCRIPTION
Update the Bencher README with the latest Torrust Tracker commit compatible with this benchmarking configuration.

How to install the Torrust Tracker to run the benchmarking:

```console
git clone git@github.com:torrust/torrust-tracker.git
cd torrust-tracker
git checkout eaa86a76fc2bca837172e0e5c0221ee14b16b122
cargo build --release
sudo cp ./target/release/torrust-tracker /usr/local/bin/
sudo chmod +x /usr/local/bin/torrust-tracker
```

How to test the configuration:

```console
TORRUST_TRACKER_CONFIG_TOML=$(cat << EOF
            [metadata]
            schema_version = "2.0.0"

            [logging]
            threshold = "error"

            [core]
            listed = false
            private = false
            tracker_usage_statistics = false

            [core.database]
            driver = "sqlite3"
            path = "./sqlite3.db"

            [core.tracker_policy]
            persistent_torrent_completed_stat = false
            remove_peerless_torrents = false

            [[udp_trackers]]
            bind_address = "0.0.0.0:3000"
EOF
) torrust-tracker
```