### PR TITLE
Implement info-hash JSON/API dump

### DIFF
--- a/crates/udp/src/config.rs
+++ b/crates/udp/src/config.rs
@@ -189,6 +189,13 @@ pub struct StatisticsConfig {
     pub json_info_hash_ipv4_file_path: PathBuf,
     /// Path to dump JSON info-hash IPv6 to
     pub json_info_hash_ipv6_file_path: PathBuf,
+    /// Save statistics as binary to a file
+    /// * this option is recommended for SSD as compares previous file before overwrite
+    pub write_bin_to_file: bool,
+    /// Path to dump binary info-hash IPv4 to
+    pub bin_info_hash_ipv4_file_path: PathBuf,
+    /// Path to dump binary info-hash IPv6 to
+    pub bin_info_hash_ipv6_file_path: PathBuf,
     /// Run a prometheus endpoint
     #[cfg(feature = "prometheus")]
     pub run_prometheus_endpoint: bool,
@@ -232,6 +239,9 @@ impl Default for StatisticsConfig {
             write_json_to_file: false,
             json_info_hash_ipv4_file_path: "tmp/info_hash_v4.json".into(),
             json_info_hash_ipv6_file_path: "tmp/info_hash_v6.json".into(),
+            write_bin_to_file: false,
+            bin_info_hash_ipv4_file_path: "tmp/info_hash_v4.bin".into(),
+            bin_info_hash_ipv6_file_path: "tmp/info_hash_v6.bin".into(),
             #[cfg(feature = "prometheus")]
             run_prometheus_endpoint: false,
             #[cfg(feature = "prometheus")]

--- a/crates/udp/src/config.rs
+++ b/crates/udp/src/config.rs
@@ -225,6 +225,10 @@ impl StatisticsConfig {
             }
         }
     }
+    /// Skip info-hash collection if not required by the configuration
+    pub fn collect_info_hash(&self) -> bool {
+        (self.interval != 0) & (self.write_json_to_file | self.write_bin_to_file)
+    }
 }
 
 impl Default for StatisticsConfig {

--- a/crates/udp/src/config.rs
+++ b/crates/udp/src/config.rs
@@ -217,11 +217,11 @@ impl StatisticsConfig {
         if #[cfg(feature = "prometheus")] {
             pub fn active(&self) -> bool {
                 (self.interval != 0) &
-                    (self.print_to_stdout | self.write_html_to_file | self.run_prometheus_endpoint)
+                    (self.print_to_stdout | self.write_html_to_file | self.write_json_to_file | self.write_bin_to_file | self.run_prometheus_endpoint)
             }
         } else {
             pub fn active(&self) -> bool {
-                (self.interval != 0) & (self.print_to_stdout | self.write_html_to_file)
+                (self.interval != 0) & (self.print_to_stdout | self.write_html_to_file | self.write_json_to_file | self.write_bin_to_file)
             }
         }
     }

--- a/crates/udp/src/config.rs
+++ b/crates/udp/src/config.rs
@@ -183,6 +183,12 @@ pub struct StatisticsConfig {
     pub write_html_to_file: bool,
     /// Path to save HTML file to
     pub html_file_path: PathBuf,
+    /// Save statistics as JSON to a file
+    pub write_json_to_file: bool,
+    /// Path to dump JSON info-hash IPv4 to
+    pub json_info_hash_ipv4_file_path: PathBuf,
+    /// Path to dump JSON info-hash IPv6 to
+    pub json_info_hash_ipv6_file_path: PathBuf,
     /// Run a prometheus endpoint
     #[cfg(feature = "prometheus")]
     pub run_prometheus_endpoint: bool,
@@ -223,6 +229,9 @@ impl Default for StatisticsConfig {
             print_to_stdout: false,
             write_html_to_file: false,
             html_file_path: "tmp/statistics.html".into(),
+            write_json_to_file: false,
+            json_info_hash_ipv4_file_path: "tmp/info_hash_v4.json".into(),
+            json_info_hash_ipv6_file_path: "tmp/info_hash_v6.json".into(),
             #[cfg(feature = "prometheus")]
             run_prometheus_endpoint: false,
             #[cfg(feature = "prometheus")]

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -183,7 +183,7 @@ impl TorrentMaps {
                     let mut t = 0;
                     let mut f = File::open(path)?;
                     loop {
-                        let mut b = vec![0, 20];
+                        let mut b = vec![0; 20];
                         let n = f.read_to_end(&mut b)?;
                         if n == 0 {
                             break;

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -185,11 +185,11 @@ impl TorrentMaps {
                     let mut f = File::open(path)?;
                     loop {
                         let mut b = vec![0; L];
-                        let n = f.read(&mut b)?;
-                        if n != L {
+                        let l = f.read(&mut b)?;
+                        if l != L {
                             break;
                         }
-                        if info_hashes.iter().any(|i| i.0 != b[..n]) {
+                        if info_hashes.iter().any(|i| i.0 != b[..l]) {
                             return Ok(false);
                         }
                         t += 1

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -184,12 +184,11 @@ impl TorrentMaps {
                     let mut t = 0;
                     let mut f = File::open(path)?;
                     loop {
-                        let mut b = vec![0; L];
-                        let l = f.read(&mut b)?;
-                        if l != L {
+                        let mut b = [0; L];
+                        if f.read(&mut b)? != L {
                             break;
                         }
-                        if !info_hashes.iter().any(|i| i.0 == b[..l]) {
+                        if !info_hashes.iter().any(|i| i.0 == b) {
                             return Ok(false);
                         }
                         t += 1

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -189,7 +189,7 @@ impl TorrentMaps {
                         if l != L {
                             break;
                         }
-                        if info_hashes.iter().any(|i| i.0 != b[..l]) {
+                        if !info_hashes.iter().any(|i| i.0 == b[..l]) {
                             return Ok(false);
                         }
                         t += 1

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -389,7 +389,7 @@ impl<I: Ip> TorrentMapShards<I> {
 
             total_num_torrents += torrent_map_shard.len();
 
-            if config.statistics.write_json_to_file {
+            if config.statistics.collect_info_hash() {
                 info_hashes.reserve(total_num_torrents);
                 for (k, _) in torrent_map_shard.iter() {
                     info_hashes.push(*k)

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -175,17 +175,18 @@ impl TorrentMaps {
             if config.statistics.write_bin_to_file {
                 use anyhow::{Context, Result};
                 use std::{fs::File, io::Read, path::PathBuf};
-                /// Prevent extra write operations by compare the file content is same
+                /// Prevent extra write operations by compare the file content is up to date
                 fn is_same(path: &PathBuf, info_hashes: &Vec<InfoHash>) -> Result<bool> {
                     if !std::fs::exists(path)? {
                         return Ok(false);
                     }
+                    const L: usize = 20; // v1 only
                     let mut t = 0;
                     let mut f = File::open(path)?;
                     loop {
-                        let mut b = vec![0; 20];
-                        let n = f.read_to_end(&mut b)?;
-                        if n == 0 {
+                        let mut b = vec![0; L];
+                        let n = f.read(&mut b)?;
+                        if n != L {
                             break;
                         }
                         if info_hashes.iter().any(|i| i.0 != b[..n]) {
@@ -204,8 +205,7 @@ impl TorrentMaps {
                         format!("File path: {}", path.to_string_lossy())
                     })?;
                     for i in info_hashes {
-                        f.write_all(&i.0)?;
-                        f.write_all(b"\n")?
+                        f.write_all(&i.0)?
                     }
                     Ok(())
                 }

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -136,14 +136,14 @@ impl TorrentMaps {
             }
 
             if config.statistics.write_json_to_file {
+                use anyhow::{Context, Result};
                 fn save_to_file(
                     path: &std::path::PathBuf,
                     info_hashes: &Vec<InfoHash>,
-                ) -> anyhow::Result<()> {
-                    let mut file =
-                        anyhow::Context::with_context(std::fs::File::create(path), || {
-                            format!("File path: {}", path.to_string_lossy())
-                        })?;
+                ) -> Result<()> {
+                    let mut file = Context::with_context(std::fs::File::create(path), || {
+                        format!("File path: {}", path.to_string_lossy())
+                    })?;
                     write!(file, "[")?;
                     if !info_hashes.is_empty() {
                         write!(file, "\"{}\"", info_hashes[0])?;
@@ -153,7 +153,7 @@ impl TorrentMaps {
                             }
                         }
                     }
-                    write!(file, "]")?; // @TODO serialize with serde_json?
+                    write!(file, "]")?;
                     Ok(())
                 }
                 if config.network.ipv4_active() {
@@ -166,6 +166,59 @@ impl TorrentMaps {
                 if config.network.ipv6_active() {
                     if let Err(err) =
                         save_to_file(&config.statistics.json_info_hash_ipv6_file_path, &ipv6.3)
+                    {
+                        ::log::error!("Couldn't dump IPv6 info-hash table to file: {:#}", err)
+                    }
+                }
+            }
+
+            if config.statistics.write_bin_to_file {
+                use anyhow::{Context, Result};
+                use std::{fs::File, io::Read, path::PathBuf};
+                /// Prevent extra write operations by compare the file content is same
+                fn is_same(path: &PathBuf, info_hashes: &Vec<InfoHash>) -> Result<bool> {
+                    if !std::fs::exists(path)? {
+                        return Ok(false);
+                    }
+                    let mut t = 0;
+                    let mut f = File::open(path)?;
+                    loop {
+                        let mut b = vec![0, 20];
+                        let n = f.read_to_end(&mut b)?;
+                        if n == 0 {
+                            break;
+                        }
+                        if info_hashes.iter().any(|i| i.0 != b[..n]) {
+                            return Ok(false);
+                        }
+                        t += 1
+                    }
+                    Ok(t == info_hashes.len())
+                }
+                /// Dump `InfoHash` index to file
+                fn save_to_file(path: &PathBuf, info_hashes: &Vec<InfoHash>) -> Result<()> {
+                    if is_same(path, info_hashes)? {
+                        return Ok(());
+                    }
+                    let mut f = Context::with_context(File::create(path), || {
+                        format!("File path: {}", path.to_string_lossy())
+                    })?;
+                    for i in info_hashes {
+                        f.write_all(&i.0)?;
+                        f.write_all(b"\n")?
+                    }
+                    Ok(())
+                }
+                if config.network.ipv4_active() {
+                    if let Err(err) =
+                        save_to_file(&config.statistics.bin_info_hash_ipv4_file_path, &ipv4.3)
+                    {
+                        ::log::error!("Couldn't dump IPv4 info-hash table to file: {:#}", err)
+                    }
+                }
+                if config.network.ipv6_active() {
+                    if let Err(err) =
+                        save_to_file(&config.statistics.bin_info_hash_ipv6_file_path, &ipv6.3)
                     {
                         ::log::error!("Couldn't dump IPv6 info-hash table to file: {:#}", err)
                     }

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -141,19 +141,19 @@ impl TorrentMaps {
                     path: &std::path::PathBuf,
                     info_hashes: &Vec<InfoHash>,
                 ) -> Result<()> {
-                    let mut file = Context::with_context(std::fs::File::create(path), || {
+                    let mut f = Context::with_context(std::fs::File::create(path), || {
                         format!("File path: {}", path.to_string_lossy())
                     })?;
-                    write!(file, "[")?;
+                    write!(f, "[")?;
                     if !info_hashes.is_empty() {
-                        write!(file, "\"{}\"", info_hashes[0])?;
+                        write!(f, "\"{}\"", info_hashes[0])?;
                         if let Some(i) = info_hashes.get(1..) {
                             for info_hash in i {
-                                write!(file, ",\"{info_hash}\"")?;
+                                write!(f, ",\"{info_hash}\"")?;
                             }
                         }
                     }
-                    write!(file, "]")?;
+                    write!(f, "]")?;
                     Ok(())
                 }
                 if config.network.ipv4_active() {

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::iter::repeat_with;
 use std::net::IpAddr;
 use std::ops::DerefMut;
@@ -133,6 +134,43 @@ impl TorrentMaps {
                     ::log::error!("couldn't send statistics message: {:#}", err);
                 }
             }
+
+            if config.statistics.write_json_to_file {
+                fn save_to_file(
+                    path: &std::path::PathBuf,
+                    info_hashes: &Vec<InfoHash>,
+                ) -> anyhow::Result<()> {
+                    let mut file =
+                        anyhow::Context::with_context(std::fs::File::create(path), || {
+                            format!("File path: {}", path.to_string_lossy())
+                        })?;
+                    write!(file, "[")?;
+                    if !info_hashes.is_empty() {
+                        write!(file, "\"{}\"", info_hashes[0])?;
+                        if let Some(i) = info_hashes.get(1..) {
+                            for info_hash in i {
+                                write!(file, ",\"{info_hash}\"")?;
+                            }
+                        }
+                    }
+                    write!(file, "]")?; // @TODO serialize with serde_json?
+                    Ok(())
+                }
+                if config.network.ipv4_active() {
+                    if let Err(err) =
+                        save_to_file(&config.statistics.json_info_hash_ipv4_file_path, &ipv4.3)
+                    {
+                        ::log::error!("Couldn't dump IPv4 info-hash table to file: {:#}", err)
+                    }
+                }
+                if config.network.ipv6_active() {
+                    if let Err(err) =
+                        save_to_file(&config.statistics.json_info_hash_ipv6_file_path, &ipv6.3)
+                    {
+                        ::log::error!("Couldn't dump IPv6 info-hash table to file: {:#}", err)
+                    }
+                }
+            }
         }
     }
 }
@@ -219,9 +257,10 @@ impl<I: Ip> TorrentMapShards<I> {
         access_list_cache: &mut AccessListCache,
         access_list_mode: AccessListMode,
         now: SecondsSinceServerStart,
-    ) -> (usize, usize, Option<Histogram<u64>>) {
+    ) -> (usize, usize, Option<Histogram<u64>>, Vec<InfoHash>) {
         let mut total_num_torrents = 0;
         let mut total_num_peers = 0;
+        let mut info_hashes: Vec<InfoHash> = Vec::new();
 
         let mut opt_histogram: Option<Histogram<u64>> = config
             .statistics
@@ -297,9 +336,21 @@ impl<I: Ip> TorrentMapShards<I> {
             torrent_map_shard.shrink_to_fit();
 
             total_num_torrents += torrent_map_shard.len();
+
+            if config.statistics.write_json_to_file {
+                info_hashes.reserve(total_num_torrents);
+                for (k, _) in torrent_map_shard.iter() {
+                    info_hashes.push(*k)
+                }
+            }
         }
 
-        (total_num_torrents, total_num_peers, opt_histogram)
+        (
+            total_num_torrents,
+            total_num_peers,
+            opt_histogram,
+            info_hashes,
+        )
     }
 
     fn get_shard(&self, info_hash: &InfoHash) -> &RwLock<TorrentMapShard<I>> {

--- a/crates/udp_protocol/src/common.rs
+++ b/crates/udp_protocol/src/common.rs
@@ -275,6 +275,19 @@ pub fn invalid_data() -> ::std::io::Error {
     ::std::io::Error::new(::std::io::ErrorKind::InvalidData, "invalid data")
 }
 
+impl std::fmt::Display for InfoHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.0
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        )
+    }
+}
+
 #[cfg(test)]
 impl quickcheck::Arbitrary for InfoHash {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {

--- a/crates/udp_protocol/src/common.rs
+++ b/crates/udp_protocol/src/common.rs
@@ -282,7 +282,7 @@ impl std::fmt::Display for InfoHash {
             "{}",
             self.0
                 .iter()
-                .map(|b| format!("{:02x}", b))
+                .map(|b| format!("{b:02x}"))
                 .collect::<String>()
         )
     }


### PR DESCRIPTION
According to #226, this patch allows the existing info-hash table to be optionally dumped to static JSON file during the stats update and used with the aggregation API (e.g., preload the torrent information from active peers collected).

New options, disabled by default:

``` rust
/// Save statistics as JSON to a file
pub write_json_to_file: bool

/// Path to dump JSON info-hash IPv4 to
pub json_info_hash_ipv4_file_path: PathBuf

/// Path to dump JSON info-hash IPv6 to
pub json_info_hash_ipv6_file_path: PathBuf
```

I have doubts about using `serde_json` for serialization, but imho the current implementation simpler.