### PR TITLE
fix: update webtorrent.dev UI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features at a glance:
 Known users:
 
 - [explodie.org public tracker](https://explodie.org/opentracker.html) (`udp://explodie.org:6969`), typically [serving ~100,000 requests per second](https://explodie.org/tracker-stats.html)
-- [tracker.webtorrent.dev](https://tracker.webtorrent.dev) (`wss://tracker.webtorrent.dev`)
+- [webtorrent.dev](https://webtorrent.dev) (`wss://tracker.webtorrent.dev`)
 
 ## Performance of the UDP implementation
 


### PR DESCRIPTION
updates the readme to reflect the new UI URL