### PR TITLE
Change monotonicity error handling; add udp cleaning tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 #### Changed
 
+* [Monotonicity errors](https://doc.rust-lang.org/std/time/struct.Instant.html)
+  deriving from the OS or the hardware are now handled explicitly and logged.
+  If such errors occur, peers may be removed (cleaned) earlier than they should
+  be, or not be removed at all, depending on which code paths are affected.
+  Some attempts are now made to mitigate such errors, but they are only partly
+  effective as the tracker needs to be able to accurately keep track of time.
 * Update dependencies
 
 ### aquatic_udp

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -21,10 +21,10 @@ pub struct ValidUntil(SecondsSinceServerStart);
 
 impl ValidUntil {
     #[inline]
-    pub fn new(start_instant: ServerStartInstant, offset_seconds: u32) -> Self {
-        Self(SecondsSinceServerStart(
-            start_instant.seconds_elapsed().0 + offset_seconds,
-        ))
+    pub fn new(start_instant: ServerStartInstant, offset_seconds: u32) -> Option<Self> {
+        start_instant
+            .seconds_elapsed()
+            .map(|elapsed| Self(SecondsSinceServerStart(elapsed.0 + offset_seconds)))
     }
     pub fn new_with_now(now: SecondsSinceServerStart, offset_seconds: u32) -> Self {
         Self(SecondsSinceServerStart(now.0 + offset_seconds))
@@ -46,14 +46,14 @@ impl ServerStartInstant {
     pub fn new() -> Self {
         Self(Instant::now())
     }
-    pub fn seconds_elapsed(&self) -> SecondsSinceServerStart {
-        SecondsSinceServerStart(
-            self.0
-                .elapsed()
+    pub fn seconds_elapsed(&self) -> Option<SecondsSinceServerStart> {
+        Instant::now().checked_duration_since(self.0).map(|dur| {
+            let seconds = dur
                 .as_secs()
                 .try_into()
-                .expect("server ran for more seconds than what fits in a u32"),
-        )
+                .expect("server ran for more seconds than what fits in a u32");
+            SecondsSinceServerStart(seconds)
+        })
     }
 }
 
@@ -200,12 +200,12 @@ impl Display for WorkerType {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ServerStartInstant, ValidUntil};
+    use crate::{SecondsSinceServerStart, ValidUntil};
 
     #[test]
     fn test_valid_until() {
-        let server_start_instant = ServerStartInstant::new();
-        let valid_until = ValidUntil::new(server_start_instant, 60);
-        assert!(valid_until.valid(server_start_instant.seconds_elapsed()));
+        let valid_until = ValidUntil::new_raw(SecondsSinceServerStart::new_raw(1));
+
+        assert!(valid_until.valid(SecondsSinceServerStart::new_raw(0)));
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -56,6 +56,12 @@ impl ServerStartInstant {
 #[derive(Debug, Clone, Copy)]
 pub struct SecondsSinceServerStart(u32);
 
+impl SecondsSinceServerStart {
+    pub fn get(&self) -> u32 {
+        self.0
+    }
+}
+
 /// SocketAddr that is not an IPv6-mapped IPv4 address
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct CanonicalSocketAddr(SocketAddr);
@@ -181,5 +187,17 @@ impl Display for WorkerType {
             #[cfg(feature = "prometheus")]
             Self::Prometheus => f.write_str("Prometheus worker"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ServerStartInstant, ValidUntil};
+
+    #[test]
+    fn test_valid_until() {
+        let server_start_instant = ServerStartInstant::new();
+        let valid_until = ValidUntil::new(server_start_instant, 60);
+        assert!(valid_until.valid(server_start_instant.seconds_elapsed()));
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -32,6 +32,10 @@ impl ValidUntil {
     pub fn valid(&self, now: SecondsSinceServerStart) -> bool {
         self.0 .0 > now.0
     }
+    /// Don't use this except for testing
+    pub fn new_raw(inner: SecondsSinceServerStart) -> Self {
+        Self(inner)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -59,6 +63,10 @@ pub struct SecondsSinceServerStart(u32);
 impl SecondsSinceServerStart {
     pub fn get(&self) -> u32 {
         self.0
+    }
+    /// Don't use this except for testing
+    pub fn new_raw(inner: u32) -> Self {
+        Self(inner)
     }
 }
 

--- a/crates/http/src/workers/socket/connection.rs
+++ b/crates/http/src/workers/socket/connection.rs
@@ -242,10 +242,14 @@ where
         request: Request,
         peer_addr: CanonicalSocketAddr,
     ) -> Result<Response, ConnectionError> {
-        *self.valid_until.borrow_mut() = ValidUntil::new(
+        if let Some(valid_until) = ValidUntil::new(
             self.server_start_instant,
             self.config.cleaning.max_connection_idle,
-        );
+        ) {
+            *self.valid_until.borrow_mut() = valid_until;
+        } else {
+            ::log::warn!("Could not update connection ValidUntil due to monotonicity error. Connection may be cleaned earlier than it should be.");
+        }
 
         match request {
             Request::Announce(request) => {

--- a/crates/http/src/workers/socket/mod.rs
+++ b/crates/http/src/workers/socket/mod.rs
@@ -134,12 +134,24 @@ impl ListenerState {
         while let Some(stream) = incoming.next().await {
             match stream {
                 Ok(stream) => {
-                    let (close_conn_sender, close_conn_receiver) = new_bounded(1);
-
-                    let valid_until = Rc::new(RefCell::new(ValidUntil::new(
+                    let opt_valid_until = ValidUntil::new(
                         self.server_start_instant,
                         self.config.cleaning.max_connection_idle,
-                    )));
+                    );
+
+                    let valid_until = if let Some(valid_until) = opt_valid_until {
+                        Rc::new(RefCell::new(valid_until))
+                    } else {
+                        ::log::warn!("clock monotonicity error, not establishing this connection");
+
+                        spawn_local(async move {
+                            stream.shutdown(std::net::Shutdown::Both);
+                        });
+
+                        continue;
+                    };
+
+                    let (close_conn_sender, close_conn_receiver) = new_bounded(1);
 
                     let connection_id =
                         self.connection_handles
@@ -231,17 +243,19 @@ async fn clean_connections(
     connection_slab: Rc<RefCell<DenseSlotMap<ConnectionId, ConnectionHandle>>>,
     server_start_instant: ServerStartInstant,
 ) -> Option<Duration> {
-    let now = server_start_instant.seconds_elapsed();
+    if let Some(now) = server_start_instant.seconds_elapsed() {
+        connection_slab.borrow_mut().retain(|_, handle| {
+            if handle.valid_until.borrow().valid(now) {
+                true
+            } else {
+                let _ = handle.close_conn_sender.try_send(());
 
-    connection_slab.borrow_mut().retain(|_, handle| {
-        if handle.valid_until.borrow().valid(now) {
-            true
-        } else {
-            let _ = handle.close_conn_sender.try_send(());
-
-            false
-        }
-    });
+                false
+            }
+        });
+    } else {
+        ::log::warn!("clock monotonicity failure, could not clean torrents and peers");
+    }
 
     Some(Duration::from_secs(
         config.cleaning.connection_cleaning_interval,

--- a/crates/http/src/workers/socket/mod.rs
+++ b/crates/http/src/workers/socket/mod.rs
@@ -145,8 +145,8 @@ impl ListenerState {
                         ::log::warn!("clock monotonicity error, not establishing this connection");
 
                         spawn_local(async move {
-                            stream.shutdown(std::net::Shutdown::Both);
-                        });
+                            let _ = stream.shutdown(std::net::Shutdown::Both).await;
+                        }).detach();
 
                         continue;
                     };

--- a/crates/http/src/workers/swarm/mod.rs
+++ b/crates/http/src/workers/swarm/mod.rs
@@ -42,15 +42,19 @@ pub async fn run_swarm_worker(
     }));
 
     let max_peer_age = config.cleaning.max_peer_age;
-    let peer_valid_until = Rc::new(RefCell::new(ValidUntil::new(
-        server_start_instant,
-        max_peer_age,
-    )));
+    let peer_valid_until = Rc::new(RefCell::new(
+        ValidUntil::new(server_start_instant, max_peer_age)
+            .expect("Could not create initial ValidUntil due to monotonicity error"),
+    ));
 
     // Periodically update peer_valid_until
     TimerActionRepeat::repeat(enclose!((peer_valid_until) move || {
         enclose!((peer_valid_until) move || async move {
-            *peer_valid_until.borrow_mut() = ValidUntil::new(server_start_instant, max_peer_age);
+            if let Some(valid_until) = ValidUntil::new(server_start_instant, max_peer_age) {
+                *peer_valid_until.borrow_mut() = valid_until;
+            } else {
+                ::log::warn!("Could not update peer_valid_until due to monotonicity error. Peers may be removed earlier than they should.");
+            }
 
             Some(Duration::from_secs(1))
         })()

--- a/crates/http/src/workers/swarm/storage.rs
+++ b/crates/http/src/workers/swarm/storage.rs
@@ -113,10 +113,12 @@ impl TorrentMaps {
     ) {
         let mut access_list_cache = create_access_list_cache(access_list);
 
-        let now = server_start_instant.seconds_elapsed();
-
-        self.ipv4.clean(config, &mut access_list_cache, now);
-        self.ipv6.clean(config, &mut access_list_cache, now);
+        if let Some(now) = server_start_instant.seconds_elapsed() {
+            self.ipv4.clean(config, &mut access_list_cache, now);
+            self.ipv6.clean(config, &mut access_list_cache, now);
+        } else {
+            ::log::warn!("Could not clean torrents due to monotonicity error");
+        }
     }
 }
 

--- a/crates/udp/src/lib.rs
+++ b/crates/udp/src/lib.rs
@@ -94,13 +94,19 @@ pub fn run(mut config: Config) -> ::anyhow::Result<()> {
                 config.cleaning.torrent_cleaning_interval,
             ));
 
-            state.torrent_maps.clean_and_update_statistics(
-                &config,
-                &statistics,
-                &statistics_sender,
-                &state.access_list,
-                state.server_start_instant.seconds_elapsed(),
-            );
+            if let Some(seconds_since_server_start) = state.server_start_instant.seconds_elapsed() {
+                state.torrent_maps.clean_and_update_statistics(
+                    &config,
+                    &statistics,
+                    &statistics_sender,
+                    &state.access_list,
+                    seconds_since_server_start,
+                );
+            } else {
+                // Note: the alternatives are to either clean nothing or remove
+                // the entire swarm, none of which are great options
+                ::log::warn!("clock monotonicity failure, could not clean torrents and peers");
+            }
         })?;
 
         join_handles.push((WorkerType::Cleaning, handle));

--- a/crates/udp/src/lib.rs
+++ b/crates/udp/src/lib.rs
@@ -99,7 +99,7 @@ pub fn run(mut config: Config) -> ::anyhow::Result<()> {
                 &statistics,
                 &statistics_sender,
                 &state.access_list,
-                state.server_start_instant,
+                state.server_start_instant.seconds_elapsed(),
             );
         })?;
 

--- a/crates/udp/src/swarm.rs
+++ b/crates/udp/src/swarm.rs
@@ -6,7 +6,6 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use aquatic_common::SecondsSinceServerStart;
-use aquatic_common::ServerStartInstant;
 use aquatic_common::{
     access_list::{create_access_list_cache, AccessListArcSwap, AccessListCache, AccessListMode},
     ValidUntil,
@@ -92,11 +91,10 @@ impl TorrentMaps {
         statistics: &CachePaddedArc<IpVersionStatistics<SwarmWorkerStatistics>>,
         statistics_sender: &Sender<StatisticsMessage>,
         access_list: &Arc<AccessListArcSwap>,
-        server_start_instant: ServerStartInstant,
+        seconds_since_server_start: SecondsSinceServerStart,
     ) {
         let mut cache = create_access_list_cache(access_list);
         let mode = config.access_list.mode;
-        let now = server_start_instant.seconds_elapsed();
 
         let mut statistics_messages = Vec::new();
 
@@ -105,14 +103,14 @@ impl TorrentMaps {
             &mut statistics_messages,
             &mut cache,
             mode,
-            now,
+            seconds_since_server_start,
         );
         let ipv6 = self.ipv6.clean_and_get_statistics(
             config,
             &mut statistics_messages,
             &mut cache,
             mode,
-            now,
+            seconds_since_server_start,
         );
 
         if config.statistics.active() {

--- a/crates/udp/src/workers/socket/mio/mod.rs
+++ b/crates/udp/src/workers/socket/mio/mod.rs
@@ -52,7 +52,8 @@ pub fn run(
     let peer_valid_until = ValidUntil::new(
         shared_state.server_start_instant,
         config.cleaning.max_peer_age,
-    );
+    )
+    .expect("Could not create initial peer ValidUntil due to monotonicity error");
 
     let mut shared = WorkerSharedData {
         config,
@@ -115,10 +116,16 @@ pub fn run(
         if iter_counter % 256 == 0 {
             shared.validator.update_elapsed();
 
-            shared.peer_valid_until = ValidUntil::new(
+            let opt_valid_until = ValidUntil::new(
                 shared.shared_state.server_start_instant,
                 shared.config.cleaning.max_peer_age,
             );
+
+            if let Some(valid_until) = opt_valid_until {
+                shared.peer_valid_until = valid_until;
+            } else {
+                ::log::warn!("Couldn't not update peer_valid until due to clock monotonicity error. As a consequence, peers may be removed earlier than they should.");
+            }
         }
 
         iter_counter = iter_counter.wrapping_add(1);

--- a/crates/udp/src/workers/socket/uring/mod.rs
+++ b/crates/udp/src/workers/socket/uring/mod.rs
@@ -195,7 +195,8 @@ impl SocketWorker {
         let peer_valid_until = ValidUntil::new(
             shared_state.server_start_instant,
             config.cleaning.max_peer_age,
-        );
+        )
+        .expect("Could not create initial peer ValidUntil due to monotonicity error");
 
         let mut worker = Self {
             config,
@@ -316,10 +317,16 @@ impl SocketWorker {
             USER_DATA_PULSE_TIMEOUT => {
                 self.validator.update_elapsed();
 
-                self.peer_valid_until = ValidUntil::new(
+                let opt_valid_until = ValidUntil::new(
                     self.shared_state.server_start_instant,
                     self.config.cleaning.max_peer_age,
                 );
+
+                if let Some(valid_until) = opt_valid_until {
+                    self.peer_valid_until = valid_until;
+                } else {
+                    ::log::warn!("Couldn't not update peer_valid until due to clock monotonicity error. As a consequence, peers may be removed earlier than they should.");
+                }
 
                 self.resubmittable_sqe_buf
                     .push(self.pulse_timeout_sqe.clone());

--- a/crates/udp/src/workers/socket/validator.rs
+++ b/crates/udp/src/workers/socket/validator.rs
@@ -97,7 +97,11 @@ impl ConnectionValidator {
     }
 
     pub fn update_elapsed(&mut self) {
-        self.seconds_since_start = self.start_time.elapsed().as_secs() as u32;
+        if let Some(dur) = Instant::now().checked_duration_since(self.start_time) {
+            self.seconds_since_start = dur.as_secs() as u32;
+        } else {
+            ::log::error!("Couldn't not update connection validator timer due to clock monotonicity error. Expired connections may not be rejected.");
+        }
     }
 
     fn hash(&mut self, elapsed: [u8; 4], ip_addr: IpAddr) -> [u8; 4] {

--- a/crates/udp/tests/cleaning.rs
+++ b/crates/udp/tests/cleaning.rs
@@ -1,0 +1,164 @@
+mod common;
+
+use aquatic_common::{CanonicalSocketAddr, ServerStartInstant, ValidUntil};
+use crossbeam_channel::unbounded;
+use rand::make_rng;
+
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::atomic::Ordering,
+};
+
+use aquatic_udp::{
+    common::{State, Statistics},
+    config::Config,
+    swarm::TorrentMaps,
+};
+use aquatic_udp_protocol::{
+    common::PeerId, AnnounceEvent, AnnounceRequest, AnnounceResponse, ConnectionId, InfoHash,
+    Ipv4AddrBytes, NumberOfBytes, NumberOfPeers, PeerKey, Port, Response, TransactionId,
+};
+
+#[test]
+fn test_cleaning() -> anyhow::Result<()> {
+    const NUM_TORRENTS: u8 = 2;
+    const NUM_PEERS: u8 = 50;
+
+    let mut config = Config::default();
+
+    config.protocol.max_response_peers = 100;
+    config.statistics.print_to_stdout = true; // Just to enable calculating statistics
+
+    let state = State::default();
+    let statistics = Statistics::new(&config);
+    let torrent_maps = TorrentMaps::default();
+    let mut rng = make_rng();
+
+    let (statistics_sender, _statistics_receiver) = unbounded();
+
+    let server_start_instant = ServerStartInstant::new();
+
+    let short = ValidUntil::new(server_start_instant, 0);
+    let long = ValidUntil::new(server_start_instant, 4);
+
+    for i in 0..NUM_TORRENTS {
+        for j in 0..NUM_PEERS {
+            let (request, src) = make_request_and_src(j, i);
+
+            let valid_until = if j % 2 == 0 { short } else { long };
+
+            let response = torrent_maps.announce(
+                &config,
+                &statistics_sender,
+                &mut rng,
+                &request,
+                src,
+                valid_until,
+            );
+
+            match response {
+                Response::AnnounceIpv4(AnnounceResponse { fixed: _, peers }) => {
+                    assert_eq!(peers.len(), j as usize);
+                }
+                _ => panic!("Wrong response type"),
+            }
+        }
+    }
+
+    // Clean out half
+
+    ::std::thread::sleep(::std::time::Duration::from_secs(1));
+
+    let elapsed = server_start_instant.seconds_elapsed().get();
+    assert!(elapsed > 0 && elapsed < 4);
+
+    torrent_maps.clean_and_update_statistics(
+        &config,
+        &statistics.swarm.clone(),
+        &statistics_sender,
+        &state.access_list,
+        server_start_instant,
+    );
+
+    assert_eq!(
+        statistics.swarm.ipv4.peers.load(Ordering::SeqCst),
+        (NUM_PEERS as usize * NUM_TORRENTS as usize) / 2
+    );
+    assert_eq!(
+        statistics.swarm.ipv4.torrents.load(Ordering::SeqCst),
+        NUM_TORRENTS as usize
+    );
+
+    for i in 0..NUM_TORRENTS {
+        let (request, src) = make_request_and_src(NUM_PEERS, i);
+
+        let response =
+            torrent_maps.announce(&config, &statistics_sender, &mut rng, &request, src, short);
+
+        match response {
+            Response::AnnounceIpv4(AnnounceResponse { fixed: _, peers }) => {
+                assert_eq!(peers.len(), NUM_PEERS as usize / 2);
+            }
+            _ => panic!("Wrong response type"),
+        }
+    }
+
+    // Clean out rest
+
+    ::std::thread::sleep(::std::time::Duration::from_secs(4));
+
+    let elapsed = server_start_instant.seconds_elapsed().get();
+    assert!(elapsed > 4);
+
+    torrent_maps.clean_and_update_statistics(
+        &config,
+        &statistics.swarm.clone(),
+        &statistics_sender,
+        &state.access_list,
+        server_start_instant,
+    );
+
+    assert_eq!(statistics.swarm.ipv4.peers.load(Ordering::SeqCst), 0);
+    assert_eq!(statistics.swarm.ipv4.torrents.load(Ordering::SeqCst), 0);
+
+    for i in 0..NUM_TORRENTS {
+        let (request, src) = make_request_and_src(NUM_PEERS, i);
+
+        let response =
+            torrent_maps.announce(&config, &statistics_sender, &mut rng, &request, src, short);
+
+        match response {
+            Response::AnnounceIpv4(AnnounceResponse { fixed: _, peers }) => {
+                assert_eq!(peers.len(), 0);
+            }
+            _ => panic!("Wrong response type"),
+        }
+    }
+
+    Ok(())
+}
+
+fn make_request_and_src(i: u8, torrent: u8) -> (AnnounceRequest, CanonicalSocketAddr) {
+    let request = AnnounceRequest {
+        connection_id: ConnectionId::new(0),
+        action_placeholder: Default::default(),
+        transaction_id: TransactionId::new(0),
+        info_hash: InfoHash([torrent; 20]),
+        peer_id: PeerId([i; 20]),
+        bytes_downloaded: NumberOfBytes::new(0),
+        bytes_uploaded: NumberOfBytes::new(0),
+        bytes_left: NumberOfBytes::new(1),
+        event: AnnounceEvent::Started,
+        ip_address: Ipv4AddrBytes([0; 4]),
+        key: PeerKey::new(0),
+        peers_wanted: NumberOfPeers::new(0),
+        port: Port::new(1.try_into().unwrap()),
+    };
+
+    let src = CanonicalSocketAddr::new(SocketAddr::V4(SocketAddrV4::new(
+        Ipv4Addr::new(127, 0, 0, i + 1),
+        1024,
+    )));
+
+    (request, src)
+}

--- a/crates/udp/tests/cleaning.rs
+++ b/crates/udp/tests/cleaning.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use aquatic_common::{CanonicalSocketAddr, ServerStartInstant, ValidUntil};
+use aquatic_common::{CanonicalSocketAddr, SecondsSinceServerStart, ValidUntil};
 use crossbeam_channel::unbounded;
 use rand::make_rng;
 
@@ -21,13 +21,13 @@ use aquatic_udp_protocol::{
 
 #[test]
 fn test_cleaning() -> anyhow::Result<()> {
-    const NUM_TORRENTS: u8 = 2;
+    const NUM_TORRENTS: u8 = 20;
     const NUM_PEERS: u8 = 50;
 
     let mut config = Config::default();
 
     config.protocol.max_response_peers = 100;
-    config.statistics.print_to_stdout = true; // Just to enable calculating statistics
+    config.statistics.print_to_stdout = true; // Just to enable storing statistics
 
     let state = State::default();
     let statistics = Statistics::new(&config);
@@ -36,10 +36,8 @@ fn test_cleaning() -> anyhow::Result<()> {
 
     let (statistics_sender, _statistics_receiver) = unbounded();
 
-    let server_start_instant = ServerStartInstant::new();
-
-    let short = ValidUntil::new(server_start_instant, 0);
-    let long = ValidUntil::new(server_start_instant, 4);
+    let short = ValidUntil::new_raw(SecondsSinceServerStart::new_raw(0));
+    let long = ValidUntil::new_raw(SecondsSinceServerStart::new_raw(2));
 
     for i in 0..NUM_TORRENTS {
         for j in 0..NUM_PEERS {
@@ -67,25 +65,20 @@ fn test_cleaning() -> anyhow::Result<()> {
 
     // Clean out half
 
-    ::std::thread::sleep(::std::time::Duration::from_secs(1));
-
-    let elapsed = server_start_instant.seconds_elapsed().get();
-    assert!(elapsed > 0 && elapsed < 4);
-
     torrent_maps.clean_and_update_statistics(
         &config,
         &statistics.swarm.clone(),
         &statistics_sender,
         &state.access_list,
-        server_start_instant,
+        SecondsSinceServerStart::new_raw(1),
     );
 
     assert_eq!(
-        statistics.swarm.ipv4.peers.load(Ordering::SeqCst),
+        statistics.swarm.ipv4.peers.load(Ordering::Relaxed),
         (NUM_PEERS as usize * NUM_TORRENTS as usize) / 2
     );
     assert_eq!(
-        statistics.swarm.ipv4.torrents.load(Ordering::SeqCst),
+        statistics.swarm.ipv4.torrents.load(Ordering::Relaxed),
         NUM_TORRENTS as usize
     );
 
@@ -105,21 +98,16 @@ fn test_cleaning() -> anyhow::Result<()> {
 
     // Clean out rest
 
-    ::std::thread::sleep(::std::time::Duration::from_secs(4));
-
-    let elapsed = server_start_instant.seconds_elapsed().get();
-    assert!(elapsed > 4);
-
     torrent_maps.clean_and_update_statistics(
         &config,
         &statistics.swarm.clone(),
         &statistics_sender,
         &state.access_list,
-        server_start_instant,
+        SecondsSinceServerStart::new_raw(3),
     );
 
-    assert_eq!(statistics.swarm.ipv4.peers.load(Ordering::SeqCst), 0);
-    assert_eq!(statistics.swarm.ipv4.torrents.load(Ordering::SeqCst), 0);
+    assert_eq!(statistics.swarm.ipv4.peers.load(Ordering::Relaxed), 0);
+    assert_eq!(statistics.swarm.ipv4.torrents.load(Ordering::Relaxed), 0);
 
     for i in 0..NUM_TORRENTS {
         let (request, src) = make_request_and_src(NUM_PEERS, i);

--- a/crates/ws/src/workers/socket/connection.rs
+++ b/crates/ws/src/workers/socket/connection.rs
@@ -550,10 +550,14 @@ impl<S: futures::AsyncRead + futures::AsyncWrite + Unpin> ConnectionWriter<S> {
         .with_context(|| "send_out_message")?;
 
         if let OutMessage::AnnounceResponse(_) | OutMessage::ScrapeResponse(_) = out_message {
-            *self.connection_valid_until.borrow_mut() = ValidUntil::new(
+            if let Some(valid_until) = ValidUntil::new(
                 self.server_start_instant,
                 self.config.cleaning.max_connection_idle,
-            );
+            ) {
+                *self.connection_valid_until.borrow_mut() = valid_until
+            } else {
+                ::log::warn!("clock monotonicity error, could not update connection_valid_until");
+            }
         }
 
         #[cfg(feature = "metrics")]

--- a/crates/ws/src/workers/socket/mod.rs
+++ b/crates/ws/src/workers/socket/mod.rs
@@ -145,16 +145,20 @@ pub async fn run_socket_worker(
                         continue;
                     }
                 };
+                let connection_valid_until = if let Some(v) =
+                    ValidUntil::new(server_start_instant, config.cleaning.max_connection_idle)
+                {
+                    Rc::new(RefCell::new(v))
+                } else {
+                    ::log::warn!("clock monotonicity error, could not open stream");
+
+                    continue;
+                };
 
                 let (out_message_sender, out_message_receiver) = new_bounded(LOCAL_CHANNEL_SIZE);
                 let out_message_sender = Rc::new(out_message_sender);
 
                 let (close_conn_sender, close_conn_receiver) = new_bounded(1);
-
-                let connection_valid_until = Rc::new(RefCell::new(ValidUntil::new(
-                    server_start_instant,
-                    config.cleaning.max_connection_idle,
-                )));
 
                 let connection_handle = ConnectionHandle {
                     close_conn_sender,
@@ -211,7 +215,30 @@ async fn clean_connections(
     server_start_instant: ServerStartInstant,
     opt_tls_config: Option<Arc<ArcSwap<RustlsConfig>>>,
 ) -> Option<Duration> {
-    let now = server_start_instant.seconds_elapsed();
+    let now = if let Some(now) = server_start_instant.seconds_elapsed() {
+        now
+    } else {
+        ::log::error!("clock monotonicity error, could not clean connections");
+
+        return Some(Duration::from_secs(
+            config.cleaning.connection_cleaning_interval,
+        ));
+    };
+    let tls_change_grace_period_valid_until = if let Some(v) = ValidUntil::new(
+        server_start_instant,
+        config.cleaning.close_after_tls_update_grace_period,
+    ) {
+        v
+    } else {
+        ::log::error!(
+            "clock monotonicity error, could not clean connections (calc TLS grace period)"
+        );
+
+        return Some(Duration::from_secs(
+            config.cleaning.connection_cleaning_interval,
+        ));
+    };
+
     let opt_current_tls_config = opt_tls_config.map(|c| c.load_full());
 
     connection_slab.borrow_mut().retain(|_, reference| {
@@ -227,10 +254,7 @@ async fn clean_connections(
             .zip(reference.opt_tls_config.as_ref())
             .map(|(a, b)| Arc::ptr_eq(a, b))
         {
-            reference.valid_until_after_tls_update = Some(ValidUntil::new(
-                server_start_instant,
-                config.cleaning.close_after_tls_update_grace_period,
-            ));
+            reference.valid_until_after_tls_update = Some(tls_change_grace_period_valid_until);
         }
 
         keep &= reference.valid_until.borrow().valid(now);

--- a/crates/ws/src/workers/swarm/storage.rs
+++ b/crates/ws/src/workers/swarm/storage.rs
@@ -71,10 +71,13 @@ impl TorrentMaps {
         server_start_instant: ServerStartInstant,
     ) {
         let mut access_list_cache = create_access_list_cache(access_list);
-        let now = server_start_instant.seconds_elapsed();
 
-        self.ipv4.clean(config, &mut access_list_cache, now);
-        self.ipv6.clean(config, &mut access_list_cache, now);
+        if let Some(now) = server_start_instant.seconds_elapsed() {
+            self.ipv4.clean(config, &mut access_list_cache, now);
+            self.ipv6.clean(config, &mut access_list_cache, now);
+        } else {
+            ::log::error!("Could not clean torrents due to clock monotonicity error.");
+        }
     }
 
     #[cfg(feature = "metrics")]
@@ -326,7 +329,12 @@ impl TorrentData {
         request: &AnnounceRequest,
         #[cfg(feature = "metrics")] peer_gauge: &::metrics::Gauge,
     ) -> PeerStatus {
-        let valid_until = ValidUntil::new(server_start_instant, config.cleaning.max_peer_age);
+        let valid_until = ValidUntil::new(server_start_instant, config.cleaning.max_peer_age)
+            .unwrap_or_else(|| {
+                ::log::warn!("announce: monotonicity error: peer may be cleaned to soon");
+
+                ValidUntil::new_raw(SecondsSinceServerStart::new_raw(0))
+            });
 
         let peer_status = PeerStatus::from_event_and_bytes_left(
             request.event.unwrap_or_default(),
@@ -432,12 +440,23 @@ impl TorrentData {
                 (offer_receiver_peer_id, offer_receiver_connection_id, offer_receiver_consumer_id),
             ) in offers.into_iter().zip(offer_receivers)
             {
+                let opt_valid_until =
+                    ValidUntil::new(server_start_instant, config.cleaning.max_offer_age);
+
+                let valid_until = if let Some(valid_until) = opt_valid_until {
+                    valid_until
+                } else {
+                    ::log::warn!("Could not send offers due to monotonicity error");
+
+                    continue;
+                };
+
                 peer.expecting_answers.insert(
                     ExpectingAnswer {
                         from_peer_id: offer_receiver_peer_id,
                         regarding_offer_id: offer.offer_id,
                     },
-                    ValidUntil::new(server_start_instant, config.cleaning.max_offer_age),
+                    valid_until,
                 );
 
                 let offer_out_message = OfferOutMessage {


### PR DESCRIPTION
In the case of monotonicity errors in ::std::time::Instant, before this change, peers may have been removed earlier than they should have, or in some cases, not been removed at all. Now we log when this condition appears and attempt to do something more reasonable than what was previously done.